### PR TITLE
update frontier to plasmnetwork/frontier

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/frontier"]
 	path = vendor/frontier
-	url = https://github.com/staketechnologies/frontier.git
+	url = https://github.com/PlasmNetwork/frontier.git

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -52,7 +52,7 @@ sc-basic-authorship = "0.8.0"
 sc-service = "0.8.0"
 sc-telemetry = "2.0.0"
 sc-consensus-babe = "0.8.0"
-frontier-consensus = { path = "../../../vendor/frontier/consensus" }
+fc-consensus = { path = "../../../vendor/frontier/client/consensus" }
 
 # plasm-specific dependencies
 lockdrop-oracle = { path = "./lockdrop-oracle" }

--- a/bin/node/rpc/Cargo.toml
+++ b/bin/node/rpc/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 [dependencies]
 plasm-runtime = { path = "../runtime" }
 plasm-primitives = { path = "../primitives" }
-frontier-rpc = { path = "../../../vendor/frontier/rpc" }
-frontier-rpc-primitives = { path = "../../../vendor/frontier/rpc/primitives" }
+fc-rpc = { path = "../../../vendor/frontier/client/rpc" }
+fp-rpc = { path = "../../../vendor/frontier/primitives/rpc" }
 jsonrpc-core = "15.0.0"
 jsonrpc-pubsub = "15.0.0"
 sp-api = "2.0.0"

--- a/bin/node/runtime/Cargo.toml
+++ b/bin/node/runtime/Cargo.toml
@@ -61,7 +61,7 @@ pallet-timestamp = { version = "2.0.0", default-features = false }
 pallet-transaction-payment = { version = "2.0.0", default-features = false }
 pallet-transaction-payment-rpc-runtime-api = { version = "2.0.0", default-features = false }
 pallet-utility = { version = "2.0.0", default-features = false }
-frontier-rpc-primitives = { path = "../../../vendor/frontier/rpc/primitives", default-features = false }
+fp-rpc = { path = "../../../vendor/frontier/primitives/rpc", default-features = false }
 pallet-ethereum = { path = "../../../vendor/frontier/frame/ethereum", default-features = false }
 
 [build-dependencies]
@@ -91,7 +91,7 @@ std = [
     "frame-executive/std",
     "frame-system/std",
     "frame-system-rpc-runtime-api/std",
-    "frontier-rpc-primitives/std",
+    "fp-rpc/std",
     "pallet-authorship/std",
     "pallet-babe/std",
     "pallet-balances/std",


### PR DESCRIPTION
**Before this is merged, there needs to be PlasmNetwork/frontier updated to paritytech/frontier master**
- [x]  Renamed frontier packages and folder paths 
- [x] Changed upstream submodule repo for PlasmNetwork/frontier 

Still unresolved dependency on parity-util-mem.
**NOT ready to merge**


```
dusty (parity-frontier2 *=) $ cargo build --release
    Updating crates.io index
    Updating git repository `https://github.com/paritytech/substrate.git`
error: failed to select a version for `parity-util-mem`.
    ... required by package `sc-cli v0.8.0`
    ... which is depended on by `plasm-cli v1.7.0 (/Users/mario/p/dusty/bin/node/cli)`
versions that meet the requirements `^0.7.0` are: 0.7.0

the package `parity-util-mem` links to the native library `parity-util-mem-ban-duplicates`, but it conflicts with a previous package which links to `parity-util-mem-ban-duplicates` as well:
package `parity-util-mem v0.8.0`
    ... which is depended on by `kvdb v0.8.0`
    ... which is depended on by `kvdb-memorydb v0.8.0`
    ... which is depended on by `sc-client-db v0.8.1 (https://github.com/paritytech/substrate.git?branch=frontier#4888ac68)`
    ... which is depended on by `sc-service v0.8.1 (https://github.com/paritytech/substrate.git?branch=frontier#4888ac68)`
    ... which is depended on by `fc-rpc v0.1.0 (/Users/mario/p/dusty/vendor/frontier/client/rpc)`
    ... which is depended on by `plasm-rpc v1.7.0 (/Users/mario/p/dusty/bin/node/rpc)`
    ... which is depended on by `plasm-cli v1.7.0 (/Users/mario/p/dusty/bin/node/cli)`

failed to select a version for `parity-util-mem` which could resolve this conflict
```

